### PR TITLE
Update Dockerfile with poetry copy ending w/ path ./

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN curl -s https://raw.githubusercontent.com/danielmiessler/SecLists/master/Pas
 RUN echo ':\nd' > openrelik-password-cracking.rules
 
 # Copy poetry toml and install dependencies
-COPY ./pyproject.toml ./poetry.lock .
+COPY ./pyproject.toml ./poetry.lock ./
 RUN poetry install --no-interaction --no-ansi
 
 # Windows password cracking


### PR DESCRIPTION
Similiar to what was done for other containers (e.g. https://github.com/openrelik/openrelik-worker-dfindexeddb/commit/ea36ded61351f59a1d828671487cd3c4278399e8)

Updating the poetry copy with a ` ./` as other CI tools complain with
```
Step 14/21 : COPY ./pyproject.toml ./poetry.lock .
When using COPY with more than one source file, the destination must be a directory and end with a /
```